### PR TITLE
add digitalclient delete methods

### DIFF
--- a/python-client/examples/DigitalClient.ipynb
+++ b/python-client/examples/DigitalClient.ipynb
@@ -30,25 +30,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "HOST = \"development.onesaitplatform.com\"\n",
+    "HOST = \"lab.onesaitplatform.com\"\n",
     "PORT = 443\n",
-    "IOT_CLIENT = \"RestaurantClient\"\n",
-    "IOT_CLIENT_TOKEN = \"669b4309e9d24412b10b8cd34aa70d88\""
+    "IOT_CLIENT = \"testclient\"\n",
+    "IOT_CLIENT_TOKEN = \"4bbad2440f8d4571be17293a562f77ae\""
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Info - IotBrokerClient will be soon deprecated, please use DigitalClient instead\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "client = DigitalClient(HOST, port=PORT, iot_client=IOT_CLIENT, iot_client_token=IOT_CLIENT_TOKEN)\n",
     "client.protocol = \"https\"\n",
@@ -62,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -92,10 +84,10 @@
     {
      "data": {
       "text/plain": [
-       "(True, {'sessionKey': '0027d4d5-a932-4391-aa98-46ca50a3891e'})"
+       "(True, {'sessionKey': '58970739-ab73-452d-811f-161d25631579'})"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -475,11 +467,56 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "# Remove Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\ebustos\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\urllib3\\connectionpool.py:847: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings\n",
+      "  InsecureRequestWarning)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "200\n",
+      "{\"nDeleted\":0,\"deleted\":[]}\n",
+      "True\n",
+      "{'nDeleted': 0, 'deleted': []}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\ebustos\\AppData\\Local\\Continuum\\anaconda3\\lib\\site-packages\\urllib3\\connectionpool.py:847: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings\n",
+      "  InsecureRequestWarning)\n"
+     ]
+    }
+   ],
+   "source": [
+    "ontology = \"testclientontology\"\n",
+    "entity_id = \"5e0f07097a5d0b000b723ffb\"\n",
+    "response_raw_delete = client.raw_delete(ontology, entity_id, True)\n",
+    "print(response_raw_delete.status_code)\n",
+    "print(response_raw_delete.text)\n",
+    "ok_delete, res_delete = client.delete(ontology, entity_id, True)\n",
+    "print(ok_delete)\n",
+    "print(res_delete)"
+   ]
   }
  ],
  "metadata": {

--- a/python-client/setup.py
+++ b/python-client/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 NAME = "onesaitplatform-client-services"
 
-VERSION = "1.3.0"
+VERSION = "1.3.1"
 
 DESCRIPTION = "Python Implementation of the Onesait Platform utilities"
 LONG_DESCRIPTION = open(path.join(path.dirname(__file__), 'README.md')).read()


### PR DESCRIPTION
Add DigitalClient delete operations as in REST API (ControlPanel)

`
ontology = "<ontology>"
entity_id = "<id>"

response_raw_delete = client.raw_delete(ontology, entity_id, True)
print(response_raw_delete.status_code)
print(response_raw_delete.text)

ok_delete, res_delete = client.delete(ontology, entity_id, True)
print(ok_delete)
print(res_delete)
`